### PR TITLE
Implémenter un debounce sur la recherche

### DIFF
--- a/index.html
+++ b/index.html
@@ -871,6 +871,18 @@
                 }
             });
         }
+        
+        let searchTimeout;
+        const searchInput = document.getElementById('searchInput');
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+            clearTimeout(searchTimeout);
+            searchTimeout = setTimeout(() => {
+                if (searchInput.value.trim()) {
+                    searchLocation();}
+                }, config.searchDelay);
+            });
+        }
 
         function handleKeyboardShortcuts(e) {
             if (e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
Tant que l’utilisateur continue de taper, délais avant l’appel à searchLocation()
Une fois qu’il a arrêté de taper pendant 500 ms, la recherche se déclenche.
Réduis ainsi le nombre de requêtes